### PR TITLE
Fix options being mutated for bank statement report

### DIFF
--- a/lib/xero-ruby/api/accounting_api.rb
+++ b/lib/xero-ruby/api/accounting_api.rb
@@ -14167,7 +14167,8 @@ module XeroRuby
    # @option opts [Date] :from_date The from date for the Bank Summary report e.g. 2018-03-31
    # @option opts [Date] :to_date The to date for the Bank Summary report e.g. 2018-03-31
    # @return [Array<(ReportWithRows, Integer, Hash)>] ReportWithRows data, response status code and response headers
-   def get_report_bank_statement_with_http_info(xero_tenant_id, bank_account_id, opts = {})
+   def get_report_bank_statement_with_http_info(xero_tenant_id, bank_account_id, options = {})
+     opts = options.dup
      if @api_client.config.debugging
        @api_client.config.logger.debug 'Calling API: AccountingApi.get_report_bank_statement ...'
      end


### PR DESCRIPTION
## Description

The options mutation bug has been resolved in the upstream repository: [issue](https://github.com/XeroAPI/xero-ruby/issues/129)

We should follow the same pattern here by duplicating the options hash for the bank statement report method.

Follows pattern of upstream repository [fix](https://github.com/XeroAPI/xero-ruby/pull/149/commits/ba90c68e1d95fe8bb4d4be295838a4382ea73110)

[vimaly](https://vimaly.com/#j8mqm/t/bugsnag_NoMethodError_in_payoutsxero_field/l8lc176aMvd5u6wcq)

Note I've also merged the upstream repository into our fork; PR releasing this into investapp should take this into consideration.